### PR TITLE
feat: add "gg" and "G" vim motions support

### DIFF
--- a/view.go
+++ b/view.go
@@ -209,6 +209,8 @@ func (m Model) renderHelpModal() string {
 	helpData := [][]string{
 		{"↑/k", "Move up"},
 		{"↓/j", "Move down"},
+		{"gg", "Move to the top"},
+		{"G", "Move to the bottom"},
 		{"Tab", "Switch views"},
 		{"Enter/Space", "Toggle details"},
 		{"?", "Toggle help"},

--- a/view.go
+++ b/view.go
@@ -239,7 +239,7 @@ func (m Model) renderHelpModal() string {
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(colorThemePurple)).
 		Padding(1, 2).
-		Width(32)
+		Width(35)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation shortcuts: “G” jumps to the bottom; double-press “g” within 500ms (“gg”) jumps to the top.
  * Improved Down/J navigation to respect current view mode and list bounds, ensuring smoother movement across endpoints and components.
  * Existing Enter/Space behavior remains unchanged.

* **Documentation**
  * Updated help modal to include “gg” (top) and “G” (bottom) shortcuts.
  * Increased help modal width for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->