### PR TITLE
feat: #4 goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,33 +1,27 @@
-name: Release
-
+name: goreleaser
 on:
-  release:
-    types:
-      - created
-
+  push:
+    tags:
+      - "*"
 permissions:
   contents: write
-  packages: write
-
 jobs:
-  releases-matrix:
-    name: Release Go Binaries
+  goreleaser:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, windows, darwin]
-        goarch: ["386", amd64, arm64]
-        exclude:
-          - goarch: "386"
-            goos: darwin
-          - goarch: arm64
-            goos: windows
     steps:
-      - uses: actions/checkout@v4
-      - uses: wangyoucao577/go-release-action@v1
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          binary_name: "oq"
-          extra_files: LICENSE README.md
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.25
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+version: 2
+project_name: oq
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - "386"
+      - amd64
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: windows
+        goarch: arm64
+    binary: oq
+archives:
+  - formats: ["tar.gz"]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]
+    files:
+      - LICENSE
+      - README.md
+homebrew_casks:
+  - name: oq
+    binary: oq
+    homepage: https://github.com/plutov/oq
+    repository:
+      owner: plutov
+      name: homebrew-tap
+release:
+  github:
+    owner: plutov
+    name: oq
+  draft: false
+  prerelease: auto
+  name_template: "v{{ .Version }}"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Both JSON and YAML formats are supported.
 
 ## Installation
 
+Using Homebrew (macOS/Linux):
+
+```bash
+brew install plutov/tap/oq
+```
+
+Or using go install:
+
 ```bash
 go install github.com/plutov/oq@latest
 ```


### PR DESCRIPTION
1. Use goreleaser
2. Publish Homebrew cask

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cross-platform release artifacts now published for Linux, macOS, and Windows (amd64, arm64; 386 where supported).
  * Added Homebrew install: brew install plutov/tap/oq.
* **Documentation**
  * Installation section updated with Homebrew and go install instructions.
* **Chores**
  * Release pipeline migrated to GoReleaser; releases are built and published from tagged pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->