### PR TITLE
feat: add Ctrl+D & Ctrl+U keys for scroll

### DIFF
--- a/view.go
+++ b/view.go
@@ -386,6 +386,8 @@ func (m Model) renderHelpModal() string {
 		{"↓/j", "Move down"},
 		{"gg", "Move to the top"},
 		{"G", "Move to the bottom"},
+		{"Ctrl-U", "Scroll up by half a screen"},
+		{"Ctrl-D", "Scroll down by half a screen"},
 		{"Tab/L", "Cycle forward through views"},
 		{"Shift+Tab/H", "Cycle backward through views"},
 		{"Enter/Space", "Toggle details"},


### PR DESCRIPTION
The number of lines to scroll with Ctrl-D and Ctrl-U is the default vim's value of `scroll` option. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added half-page scrolling with keyboard shortcuts: Ctrl-D (down) and Ctrl-U (up) across all lists.

- Bug Fixes
  - Consistent navigation across views; prevents cursor overshoot and keeps selection visible when paging.
  - Down/j navigation refined to maintain selection visibility.
  - Improved “G” behavior to reliably jump to the true end of the list.

- Documentation
  - Help modal updated to include Ctrl-U and Ctrl-D shortcuts for half-page scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->